### PR TITLE
fix: upload a correct json object instead a string object

### DIFF
--- a/src/AnnOtter.WayToSecureExchange/Controllers/API/ExchangeAPIController.cs
+++ b/src/AnnOtter.WayToSecureExchange/Controllers/API/ExchangeAPIController.cs
@@ -131,11 +131,13 @@ namespace AnnOtter.WayToSecureExchange.Controllers.API
         /// <param name="data">ID to identify a secret uniquely.</param>
         /// <returns>Confirmation of the upload process. If successful, transmits HTTP status code 200 (ok) with a confirmation object; if an error occurs, transmits 500 (server error).</returns>
         [HttpPost("upload")]
-        public ActionResult<UploadConfirmationModel> Upload([FromBody] string data)
+        public ActionResult<UploadConfirmationModel> Upload([FromBody] UploadDataModel uploadData)
         {
             try
             {
-                if (string.IsNullOrEmpty(data))
+                var data = (uploadData != null && !string.IsNullOrEmpty(uploadData.Data)) ? uploadData.Data : string.Empty;
+
+                if (data == null || string.IsNullOrEmpty(data))
                 {
                     throw new InputDataInvalidException("Validation Error: data must not be empty.");
                 }

--- a/src/AnnOtter.WayToSecureExchange/Models/API/Exchange/UploadDataModel.cs
+++ b/src/AnnOtter.WayToSecureExchange/Models/API/Exchange/UploadDataModel.cs
@@ -1,0 +1,14 @@
+﻿namespace AnnOtter.WayToSecureExchange.Models.API.Exchange
+{
+    /// <summary>
+    /// Represents the model for the upload data
+    /// </summary>
+    public class UploadDataModel
+    {
+        /// <summary>
+        /// Contains the ciphertext to be uploaded.
+        /// This encrypted data is sent by the client.
+        /// </summary>
+        public string? Data { get; set; }
+    }
+}

--- a/src/AnnOtter.WayToSecureExchange/Views/Shared/_Layout_aow2sx.cshtml
+++ b/src/AnnOtter.WayToSecureExchange/Views/Shared/_Layout_aow2sx.cshtml
@@ -11,8 +11,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/css/main.css?v=0.14.0" integrity="sha384-7NQGVgDfKczpdY62troz1wxpxE6eOq8ClE+WMkEKM460fchBJBZheLu3F4DCv6ea" />
-    <link rel="stylesheet" href="/css/theme.css?v=0.14.0" />
+    <link rel="stylesheet" href="/css/main.css?v=0.14.1" integrity="sha384-7NQGVgDfKczpdY62troz1wxpxE6eOq8ClE+WMkEKM460fchBJBZheLu3F4DCv6ea" />
+    <link rel="stylesheet" href="/css/theme.css?v=0.14.1" />
     <link rel="stylesheet" href="/lib/bootstrap-5.3.0-alpha3-dist/css/bootstrap.min.css" integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ">
     <title>@ViewData["Title"] - @browserTitle</title>
 
@@ -38,13 +38,13 @@
         </main>
 
         <footer class="mt-auto text-ao">
-            <p>v0.14.0 // <i class="fa-brands fa-github footerLink"></i> <a class="footerLink" href="https://github.com/daniiiol/AnnOtter.WayToSecureExchange" target="_blank" rel="noopener" title="Check out our GitHub Repository for the source code and contributions.">GitHub Repository</a></p>
+            <p>v0.14.1 // <i class="fa-brands fa-github footerLink"></i> <a class="footerLink" href="https://github.com/daniiiol/AnnOtter.WayToSecureExchange" target="_blank" rel="noopener" title="Check out our GitHub Repository for the source code and contributions.">GitHub Repository</a></p>
         </footer>
     </div>
 
     <script src="/lib/bootstrap-5.3.0-alpha3-dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe"></script>
-    <script src="/js/aes.js?v=0.14.0" integrity="sha384-Wqw7eLuMAKohF3NUxOr+sp26R/j60QAeinMBfJ6wP9Q/tJ//yYIenRX7BjkyBm4S"></script>
-    <script src="/js/site.js?v=0.14.0" integrity="sha384-iqF+DrgDZAFeWk50QLRFnaGawGW52QQ5DaRaUU+agD1qYrPJuC8iqbjdtR30XvHR"></script>
+    <script src="/js/aes.js?v=0.14.1" integrity="sha384-Wqw7eLuMAKohF3NUxOr+sp26R/j60QAeinMBfJ6wP9Q/tJ//yYIenRX7BjkyBm4S"></script>
+    <script src="/js/site.js?v=0.14.1" integrity="sha384-7dlJsCmvfZ/CRh61dKBO0lCorAxz/9CgNJTaCLPWNC4nlccQVmm6UWz//zkMf524"></script>
 </body>
 
 </html>

--- a/src/AnnOtter.WayToSecureExchange/appsettings.Development.json
+++ b/src/AnnOtter.WayToSecureExchange/appsettings.Development.json
@@ -12,7 +12,7 @@
     "RetentionSpan": "30.00:00:00"
   },
   "SecurityHeaders": {
-    "ContentSecurityPolicy": "default-src 'self'; script-src 'sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe' 'sha384-Wqw7eLuMAKohF3NUxOr+sp26R/j60QAeinMBfJ6wP9Q/tJ//yYIenRX7BjkyBm4S' 'sha384-iqF+DrgDZAFeWk50QLRFnaGawGW52QQ5DaRaUU+agD1qYrPJuC8iqbjdtR30XvHR'; style-src 'self' 'unsafe-inline';object-src 'none';require-trusted-types-for 'script'; img-src 'self' data: 'unsafe-eval'; ",
+    "ContentSecurityPolicy": "default-src 'self'; script-src 'sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe' 'sha384-Wqw7eLuMAKohF3NUxOr+sp26R/j60QAeinMBfJ6wP9Q/tJ//yYIenRX7BjkyBm4S' 'sha384-7dlJsCmvfZ/CRh61dKBO0lCorAxz/9CgNJTaCLPWNC4nlccQVmm6UWz//zkMf524'; style-src 'self' 'unsafe-inline';object-src 'none';require-trusted-types-for 'script'; img-src 'self' data: 'unsafe-eval'; ",
     "XFrameOptions": "DENY",
     "XSSProtection": "1; mode=block",
     "ContentTypeOptions": "nosniff",

--- a/src/AnnOtter.WayToSecureExchange/appsettings.json
+++ b/src/AnnOtter.WayToSecureExchange/appsettings.json
@@ -12,7 +12,7 @@
     "RetentionSpan": "30.00:00:00"
   },
   "SecurityHeaders": {
-    "ContentSecurityPolicy": "default-src 'self'; script-src 'sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe' 'sha384-Wqw7eLuMAKohF3NUxOr+sp26R/j60QAeinMBfJ6wP9Q/tJ//yYIenRX7BjkyBm4S' 'sha384-iqF+DrgDZAFeWk50QLRFnaGawGW52QQ5DaRaUU+agD1qYrPJuC8iqbjdtR30XvHR'; style-src 'self' 'unsafe-inline';object-src 'none';require-trusted-types-for 'script'; img-src 'self' data: 'unsafe-eval'; ",
+    "ContentSecurityPolicy": "default-src 'self'; script-src 'sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe' 'sha384-Wqw7eLuMAKohF3NUxOr+sp26R/j60QAeinMBfJ6wP9Q/tJ//yYIenRX7BjkyBm4S' 'sha384-7dlJsCmvfZ/CRh61dKBO0lCorAxz/9CgNJTaCLPWNC4nlccQVmm6UWz//zkMf524'; style-src 'self' 'unsafe-inline';object-src 'none';require-trusted-types-for 'script'; img-src 'self' data: 'unsafe-eval'; ",
     "XFrameOptions": "DENY",
     "XSSProtection": "1; mode=block",
     "ContentTypeOptions": "nosniff",

--- a/src/AnnOtter.WayToSecureExchange/wwwroot/js/site.js
+++ b/src/AnnOtter.WayToSecureExchange/wwwroot/js/site.js
@@ -509,9 +509,14 @@ async function UploadCiphertext(ciphertext) {
     const host = window.location.protocol + "//" + window.location.host;
     const url = host + '/api/exchange/upload';
 
+    // Wrap the ciphertext in an object with the "data" property
+    const payload = {
+        data: ciphertext
+    };
+
     const requestOptions = {
         method: 'POST',
-        body: JSON.stringify(ciphertext),
+        body: JSON.stringify(payload),
         headers: {
             'Content-Type': 'application/json',
         },

--- a/src/cli-tool/ao-w2se.py
+++ b/src/cli-tool/ao-w2se.py
@@ -39,7 +39,8 @@ def encrypt_aes_gcm(plaintext):
 
 def send_post_request(url, data):
     headers = {'Content-Type': 'application/json'}
-    response = requests.post(url, json=data, headers=headers)
+    payload = {'data': data}
+    response = requests.post(url, json=payload, headers=headers)
     return response
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Bugfixes

- The transmitted data object (ciphertext) was an unformatted string, although a JSON object was expected. This sometimes led to an error with web application firewalls (missmatching mime-type and payload). This has been corrected by expecting an explicit JSON object with a `data`-property.